### PR TITLE
Added parens for lubridate

### DIFF
--- a/R/get_player_profile.R
+++ b/R/get_player_profile.R
@@ -416,7 +416,7 @@ get_headers <-
   }
 
 get_nba_players_ids <- function(active_only = c(F, T)) {
-  if(Sys.Date() %>% lubridate::month >= 10){
+  if(Sys.Date() %>% lubridate::month () >= 10){
     year.season_start <-
       Sys.Date() %>%
       year

--- a/R/split_functions.R
+++ b/R/split_functions.R
@@ -1271,7 +1271,7 @@ get_teams_season_stat_splits <-
 
 
 get_nba_players_ids <- function(active_only = c(F, T)) {
-  if (Sys.Date() %>% lubridate::month >= 10) {
+  if (Sys.Date() %>% lubridate::month () >= 10) {
     year.season_start <-
       Sys.Date() %>%
       year


### PR DESCRIPTION
I was getting an error when trying to install nbastatR, the error was:
Error in .::lubridate : unused argument (month)

I found the line in the code and figured out by adding a set of parenthesis ()
I was able to fix the issue (which meant I could now install the package)