### PR TITLE
home and away scores on pbp data from nba.com were reversed (fixed)

### DIFF
--- a/R/new_ish.R
+++ b/R/new_ish.R
@@ -1387,7 +1387,7 @@ munge_nba_data <- function(data) {
   if (data %>% tibble::has_name("slugScore")) {
     data <-
       data %>%
-      tidyr::separate(slugScore, into = c("scoreHome", "scoreAway"), sep = "\\ - ", remove = F) %>%
+      tidyr::separate(slugScore, into = c("scoreAway", "scoreHome"), sep = "\\ - ", remove = F) %>%
       mutate_at(c("scoreHome", "scoreAway"),
                 funs(. %>% as.numeric())) %>%
       mutate(slugTeamLeading = case_when(marginScore == 0 ~ "Tie",


### PR DESCRIPTION
Hey Alex - As mentioned in the twitter thread, I found a small error in the nbastatR package. I think this should fix the play by play data scores. The home scores was previously labeled as awayScore and vice versa on the away scores. It's a pretty minor change. 