### PR TITLE
Change current_schedule to handle 2019/20 schedule response from data.nba.net

### DIFF
--- a/R/new_stats.R
+++ b/R/new_stats.R
@@ -17981,6 +17981,7 @@ current_schedule <-
 
     df_season_games <-
       df_season_games %>%
+      select(1:10) %>%
       purrr::set_names(
         c(
           "slugGame",
@@ -17992,11 +17993,9 @@ current_schedule <-
           "datetimeGame",
           "dateSlugGame",
           "timeEasternGame",
-          "hasBuzzerBeater",
-          "tags"
+          "hasBuzzerBeater"
         )
       ) %>%
-      select(-one_of("tags")) %>%
       tidyr::separate(slugGameCode,
                       into = c("idGame", "slugTeams"),
                       sep = "/")


### PR DESCRIPTION
data.nba.net schedule call is currently only returning 10 elements where the existing code expects 11.  Specifically, the code is trying to set the names for a 'tags' column that is missing.  Since the 'tags' were getting dropped anyway, selecting the first 10 columnns prior to assigning names appears to get this working again (and should be fairly backwards/future compatible?)