### PR TITLE
Update new_stats.R team logos URL

### DIFF
--- a/R/new_stats.R
+++ b/R/new_stats.R
@@ -18365,7 +18365,7 @@ parse_for_seasons_data <-
         urlThumbnailTeam = if_else(
           isNonNBATeam == 0,
           glue(
-            "https://stats.nba.com/media/img/teams/logos/{slugTeam}_logo.svg"
+            "https://cdn.nba.com/logos/nba/{idTeam}/primary/L/logo.svg"
           ) %>% as.character(),
           "https://stats.nba.com/media/img/teams/logos/NBA_logo.svg"
         )


### PR DESCRIPTION
The current location of team logos at stats.nba.com are broken and are not showing up. I tried to fix them using another location.